### PR TITLE
Support additional arches

### DIFF
--- a/src/bin/with_snap_arch_triplet
+++ b/src/bin/with_snap_arch_triplet
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 case "${SNAP_ARCH}" in
+  # These are the special cases
   amd64)
     TRIPLET=x86_64-linux-gnu
   ;;
@@ -16,6 +17,7 @@ case "${SNAP_ARCH}" in
   ppc64el)
     TRIPLET=powerpc64le-linux-gnu
   ;;
+  # Consider rest of them not exceptions
   s390x \
   |*)
     TRIPLET="${SNAP_ARCH}"-linux-gnu

--- a/src/bin/with_snap_arch_triplet
+++ b/src/bin/with_snap_arch_triplet
@@ -1,14 +1,26 @@
 #!/bin/sh
 
-if [ "$SNAP_ARCH" = "amd64" ]; then
-  TRIPLET="x86_64-linux-gnu"
-elif [ "$SNAP_ARCH" = "armhf" ]; then
-  TRIPLET="arm-linux-gnueabihf"
-elif [ "$SNAP_ARCH" = "arm64" ]; then
-  TRIPLET="aarch64-linux-gnu"
-else
-  TRIPLET="$SNAP_ARCH-linux-gnu"
-fi
+case "${SNAP_ARCH}" in
+  amd64)
+    TRIPLET=x86_64-linux-gnu
+  ;;
+  armel)
+    TRIPLET=arm-linux-gnueabi
+  ;;
+  armhf)
+    TRIPLET=arm-linux-gnueabihf
+  ;;
+  arm64)
+    TRIPLET=aarch64-linux-gnu
+  ;;
+  ppc64el)
+    TRIPLET=powerpc64le-linux-gnu
+  ;;
+  s390x \
+  |*)
+    TRIPLET="${SNAP_ARCH}"-linux-gnu
+  ;;
+esac
 
 export SNAP_ARCH_TRIPLET=$TRIPLET
 exec "$@"

--- a/src/bin/with_snap_arch_triplet
+++ b/src/bin/with_snap_arch_triplet
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Refer:
+#
+# * Environmental variables - doc - snapcraft.io
+#   https://forum.snapcraft.io/t/environmental-variables/7983
+# * Multiarch/Tuples - Debian Wiki
+#   https://wiki.debian.org/Multiarch/Tuples
+#   NOTE: Only consider Linux archs with the `released` status in Debian for now
 case "${SNAP_ARCH}" in
   # These are the special cases
   amd64)


### PR DESCRIPTION
This patch implements logic to deal with the additional supported
architectures on b-s-i, currently unsupported architectures are also
added as well just for completeness.

Refer-to: Multiarch/Tuples - Debian Wiki
<https://wiki.debian.org/Multiarch/Tuples>
Refer-to: More architectures enabled in build.snapcraft.io - snapcraft - snapcraft.io <https://forum.snapcraft.io/t/more-architectures-enabled-in-build-snapcraft-io/7733>